### PR TITLE
Tangerine Server in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:14.04
 ADD ./ /root/Tangerine-server
 RUN cd /root/Tangerine-server && cp tangerine-env-vars.sh.defaults tangerine-env-vars.sh && ./server-init.sh
-VOLUME ["/usr/local/var/lib/couchdb"]
 EXPOSE 80
 ENTRYPOINT /root/Tangerine-server/container-start.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:14.04
 ADD ./ /root/Tangerine-server
 RUN cd /root/Tangerine-server && cp tangerine-env-vars.sh.defaults tangerine-env-vars.sh && ./server-init.sh
-ENTRYPOINT ["pm2", "start", "/root/Tangerine-server/ecosystem.json"]
+ENTRYPOINT /root/Tangerine-server/container-start.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM ubuntu:14.04
+ENV T_HOSTNAME local.tangerinecentral.org
+ENV T_ADMIN admin
+ENV T_PASS password
+ENV T_COUCH_HOST localhost
+ENV T_COUCH_PORT 5984
+ENV T_ROBBERT_PORT 4444
+ENV T_TREE_PORT 4445
+ENV T_BROCKMAN_PORT 4446
+ENV T_DECOMPRESSOR_PORT 4447
+
 ADD ./ /root/Tangerine-server
 RUN cd /root/Tangerine-server && cp tangerine-env-vars.sh.defaults tangerine-env-vars.sh && ./server-init.sh
 EXPOSE 80
-ENTRYPOINT /root/Tangerine-server/container-start.sh 
+ENTRYPOINT /root/Tangerine-server/entrypoint.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
 ADD ./ /root/Tangerine-server
 RUN cd /root/Tangerine-server && cp tangerine-env-vars.sh.defaults tangerine-env-vars.sh && ./server-init.sh
+VOLUME ["/usr/local/var/lib/couchdb"]
+EXPOSE 80
 ENTRYPOINT /root/Tangerine-server/container-start.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:14.04
+ADD ./ /root/Tangerine-server
+RUN cd /root/Tangerine-server && cp tangerine-env-vars.sh.defaults tangerine-env-vars.sh && ./server-init.sh
+ENTRYPOINT ["pm2", "start", "/root/Tangerine-server/ecosystem.json"]

--- a/README.md
+++ b/README.md
@@ -4,17 +4,27 @@ This repo is meant to contain submodules references to each component required f
 
 # Gettings started with Docker
 
-Build the image yourself.
-```
-docker build -t tangerine/tangerine-server .
-```
-
-Run the image.
+Run the prebuilt image.
 ```
 docker run -d --name tangerine-server-container -p 80:80 tangerine/tangerine-server
 ```
 
 Now add an entry to our `/etc/hosts` file to point to the IP address of your Docker so that it responds at the hostname of `local.tangerinecentral.org`.  Then go to `http://local.tangerinecentral.org/` in your browser.
+
+Sandbox time! Run the prebuilt image but override it with your local code. Here's an example that works on R.J.'s laptop. The path to the code folder will be different for you. Just make sure you make that an absolute path, not relative like `./`. 
+```
+docker run -d --name tangerine-server-container -p 80:80 --volume /Users/rsteinert/Github/Tangerine-Community/Tangerine-server/:/root/Tangerine-server tangerine/tangerine-server
+```
+
+Build the image yourself.
+```
+docker build -t tangerine/tangerine-server .
+```
+
+Push up your new image.
+```
+docker push tangerine/tangerine-server 
+```
 
 Get into a running container to play around.
 ```

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This repo is meant to contain submodules references to each component required f
 
 Build the image yourself.
 ```
-docker build tangerine-server-image .
+docker build -t tangerine/tangerine-server .
 ```
 
 Run the image.
 ```
-docker run -d --name tangerine-server-container -p 80:80 tangerine-server-image
+docker run -d --name tangerine-server-container -p 80:80 tangerine/tangerine-server
 ```
 
 Now add an entry to our `/etc/hosts` file to point to the IP address of your Docker so that it responds at the hostname of `local.tangerinecentral.org`.  Then go to `http://local.tangerinecentral.org/` in your browser.
@@ -23,7 +23,7 @@ docker exec -it tangerine-server-container /bin/bash
 
 Is the container crashing on start so the above isn't working? Override the entrypoint command to start the container with just `/bin/bash`. 
 ```
-docker run -it tangerine-server-image /bin/bash
+docker run -it --entrypoint=/bin/bash tangerine/tangerine-server
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run the image.
 docker run -d --name tangerine-server-container -p 80:80 tangerine-server-image
 ```
 
-Now add an entry to our `/etc/hosts` file to point to the IP address your Docker is running so that it responds at the hostname of `tangerine`.  Then go to `http://tangerine/` in your browser.
+Now add an entry to our `/etc/hosts` file to point to the IP address of your Docker so that it responds at the hostname of `local.tangerinecentral.org`.  Then go to `http://local.tangerinecentral.org/` in your browser.
 
 Get into a running container to play around.
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 This repo is meant to contain submodules references to each component required for the tangerine server, removing some manual steps to Tangerine server installation.
 
-# Getting started
+# Gettings started with Docker
+
+Build the image yourself.
+```
+docker build tangerine-server-image .
+```
+
+Run the image.
+```
+docker run -d --name tangerine-server-container -p 80:80 tangerine-server-image
+```
+
+Now add an entry to our `/etc/hosts` file to point to the IP address your Docker is running so that it responds at the hostname of `tangerine`.  Then go to `http://tangerine/` in your browser.
+
+Get into a running container to play around.
+```
+docker exec -it tangerine-server-container /bin/bash 
+```
+
+Is the container crashing on start so the above isn't working? Override the entrypoint command to start the container with just `/bin/bash`. 
+```
+docker run -it tangerine-server-image /bin/bash
+```
+
+
+# Getting started without Docker
 
 Spin up an Ubuntu 14.04 machine and then ssh into it.
 

--- a/container-start.sh
+++ b/container-start.sh
@@ -1,2 +1,6 @@
+sudo mkdir /var/run/couchdb
+sudo chown -R couchdb /var/run/couchdb
+couchdb -k
+couchdb -b
 cd /root/Tangerine-server
 pm2 start --no-daemon ecosystem.json

--- a/container-start.sh
+++ b/container-start.sh
@@ -1,0 +1,2 @@
+cd /root/Tangerine-server
+pm2 start --no-daemon ecosystem.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,6 @@ sudo mkdir /var/run/couchdb
 sudo chown -R couchdb /var/run/couchdb
 couchdb -k
 couchdb -b
+service nginx start
 cd /root/Tangerine-server
 pm2 start --no-daemon ecosystem.json

--- a/tangerine-env-vars.sh.defaults
+++ b/tangerine-env-vars.sh.defaults
@@ -1,5 +1,5 @@
 # these are the things you're most likely to want to change
-export T_HOSTNAME=tangerine
+export T_HOSTNAME=local.tangerinecentral.org
 export T_ADMIN=admin
 export T_PASS=password
 

--- a/tangerine-env-vars.sh.defaults
+++ b/tangerine-env-vars.sh.defaults
@@ -1,5 +1,5 @@
 # these are the things you're most likely to want to change
-export T_HOSTNAME=localhost
+export T_HOSTNAME=tangerine
 export T_ADMIN=admin
 export T_PASS=password
 


### PR DESCRIPTION
I spent some time today putting the current server set up in a Docker container. 

To try it out, set your `/etc/hosts` file so local.tangerinecentral.org points to the IP address of where your Docker is running. Then run...
```
docker run -d --name tangerine-server-container -p 80:80 rjsteinert/tangerine-server
```
Then go to `http://local.tangerinecentral.org` in your browser. The default user is user1:password.

Want to peak into the container? Run this.
```
docker exec -it tangerine-server-container /bin/bash
```

Areas where I think we can improve:

- Better handling of environment variables. We're in some in between stage where some are defined in the Dockerfile but also defined in an environment file in the code. 
- It's a monolithic container. Couchdb, tree, etc. are all in the same container. That's not "[best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)" but not the end of the world necessarily. 
- This issue is bad. Currently the data is stored in the container which means if we upgrade that container we'll lose the data. Best practice is to store the data outside of the container using a "Volume" in your Dockerfile to say what folder inside should be mapped outside. Problem is, when the data is mapped outside and the container is updated, the application code is not actually updated because it's in the data outside of the container! My solution for this is possibly making sure that the entrypoint script runs couchapp push every time the container starts. 