### PR TITLE
Access Control Lists for Tangerine Server

### DIFF
--- a/editor/app/_docs/acl.json
+++ b/editor/app/_docs/acl.json
@@ -1,0 +1,15 @@
+{
+  "_id": "acl",
+  "groups": [
+    {
+      "name": "Starter group",
+      "creator": "admin",
+      "users": ["admin", "user1"],
+      "permissions": [
+          "Create new group",
+          "Edit group's own content",
+          "Create group content"
+      ]
+    }
+  ]
+}

--- a/robbert/Acl.js
+++ b/robbert/Acl.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var nano = require('nano')('http://admin:password@localhost:5984');
+var db = nano.db.use('tangerine');
+
+module.exports = function(permission, user, context, callback) {
+
+  db.get('acl', function(err, body) {
+    body.groups.forEach(function(group) {
+      if(group.users.indexOf(user) !== -1 && group.permissions.indexOf(permission) !== -1) {
+        return callback(null, true)
+      }
+      else {
+        callback(null, false)
+      }
+    })
+  })
+
+}
+

--- a/robbert/Acl.js
+++ b/robbert/Acl.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var nano = require('nano')('http://admin:password@localhost:5984');
+let Conf = require('./Conf');
+var nano = require('nano')(Conf.protocol + Conf.auth + Conf.serverUrl);
 var db = nano.db.use('tangerine');
 
 module.exports = function(permission, user, context, callback) {
 
   db.get('acl', function(err, body) {
+    if (err) return callback(err, false)
     body.groups.forEach(function(group) {
       if(group.users.indexOf(user) !== -1 && group.permissions.indexOf(permission) !== -1) {
         return callback(null, true)

--- a/robbert/package.json
+++ b/robbert/package.json
@@ -23,6 +23,7 @@
     "express": "^4.13.3",
     "http-status-codes": "^1.0.5",
     "mocha": "^2.3.4",
+    "nano": "^6.2.0",
     "unirest": "^0.4.2",
     "winston": "^2.1.1"
   }

--- a/robbert/routes/group/new-group.js
+++ b/robbert/routes/group/new-group.js
@@ -29,6 +29,15 @@ function newGroup(req, res) {
 
   Acl('Create new group',req.couchAuth.body.userCtx.name, 'global', function(err, hasPermission) { 
 
+    if (err) {
+      logger.warn('Group creation failed: Internal error.');
+      logger.warn(err)
+      return res.status(HttpStatus.UNAUTHORIZED)
+        .json({
+          message : 'There was an error. Try again later.'
+        });
+    }
+
     if (hasPermission == false) {
       logger.warn('Group creation failed: Insufficient permission.');
       return res.status(HttpStatus.UNAUTHORIZED)

--- a/robbert/routes/group/new-group.js
+++ b/robbert/routes/group/new-group.js
@@ -2,6 +2,7 @@
 
 const Group = require('../../Group');
 const User = require('../../User');
+const Acl = require('../../Acl');
 
 const logger = require('../../logger');
 const HttpStatus = require('http-status-codes');
@@ -16,7 +17,7 @@ const errorHandler = require('../../utils/errorHandler');
 function newGroup(req, res) {
 
   logger.info(`New group: ${JSON.stringify(req.body)}`);
-
+  
   const notEvenLoggedIn = req.couchAuth.body.userCtx.name === null;
   if (notEvenLoggedIn) {
     logger.warn('Group creation failed: User not logged in');
@@ -26,32 +27,45 @@ function newGroup(req, res) {
       });
   }
 
-  const groupName = req.body.name;
-  const nameFromCookie = req.couchAuth.body.userCtx.name;
+  Acl('Create new group',req.couchAuth.body.userCtx.name, 'global', function(err, hasPermission) { 
 
-  const requestingUser = new User({
-    name : nameFromCookie
-  });
-  const group = new Group({
-    name : groupName
-  });
-
-  logger.info(`New group '${group.name()}' request by '${requestingUser.name()}'`)
-
-  group.create()
-    .then(function addAdmin() {
-      return requestingUser.grantAdmin(group);
-    })
-    .then(function respondOk() {
-      const message = `New group '${groupName}' created`;
-      logger.info(message)
-      res
-        .status(HttpStatus.CREATED)
+    if (hasPermission == false) {
+      logger.warn('Group creation failed: Insufficient permission.');
+      return res.status(HttpStatus.UNAUTHORIZED)
         .json({
-          message : message
+          message : 'Insufficient permission'
         });
-    })
-    .catch(errorHandler(res));
+    }
+
+    const groupName = req.body.name;
+    const nameFromCookie = req.couchAuth.body.userCtx.name;
+
+    const requestingUser = new User({
+      name : nameFromCookie
+    });
+    const group = new Group({
+      name : groupName
+    });
+
+    logger.info(`New group '${group.name()}' request by '${requestingUser.name()}'`)
+
+    group.create()
+      .then(function addAdmin() {
+        return requestingUser.grantAdmin(group);
+      })
+      .then(function respondOk() {
+        const message = `New group '${groupName}' created`;
+        logger.info(message)
+        res
+          .status(HttpStatus.CREATED)
+          .json({
+            message : message
+          });
+      })
+      .catch(errorHandler(res));
+
+  })
+
 }
 
 module.exports = newGroup;


### PR DESCRIPTION
This pull request creates a default Acl.json document to be pushed up to the tangerine database, an `Acl.js` module that other code can use to test if user has sufficient permission, and a use of `Acl.js` in `new-group.js`.